### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the API with no providers:
 
 	pod 'GRKAnalytics/Core'
 
-If you are not using Cocoapods, simply add the top level *.m and *.h files, and the
+If you are not using CocoaPods, simply add the top level *.m and *.h files, and the
 provider(s) you wish from the `Providers` directory to your project.
 
 NOTE: You will be responsible for adding the dependent provider library/libraries


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
